### PR TITLE
List all available versions of elasticsearch

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -1,4 +1,11 @@
 #!/usr/bin/env bash
-releases_path=https://api.github.com/repos/elastic/elasticsearch/tags
-versions=$(curl -s $releases_path | awk -F':' '/\"name\"\:/ {gsub(/\"v|\"|\,/,"",$2);print $2}' | sort)
-echo $versions
+releases_path=https://api.github.com/repos/elastic/elasticsearch/tags?per_page=100
+total_pages=$(curl -I $releases_path | awk -F'[=>]' '/Link:/ {print $(NF-2)}')
+current_page=1
+versions=''
+while [ $current_page -le $total_pages ]
+do
+  versions+=$(curl -s "$releases_path&page=$current_page" | awk -F':' '/\"name\"\:/ {gsub(/\"v|\"|\,/,"",$2);print $2}')
+  current_page=$(( $current_page + 1 ))
+done
+echo $versions | sort


### PR DESCRIPTION
List all available version of elasticsearch instead of only 30 latest versions provided by default from github api.

https://developer.github.com/v3/#pagination

Use awk to fetch total_pages and loop through them to list all versions

https://developer.github.com/v3/guides/traversing-with-pagination/